### PR TITLE
Support lisp implementations other than ECL

### DIFF
--- a/build.lisp
+++ b/build.lisp
@@ -5,20 +5,10 @@
 
 (format t "--- LOADING SYSTEM ---~%")
 (declaim (optimize (speed 3) (debug 1) (safety 1)))
-(asdf:load-system :vend)
 
-#-ecl
-(progn
-  (format t "--- NO OP! ---~%")
-  (format t "Use ECL instead.~%")
-  #+sbcl (sb-ext:exit :code 1))
 
-#+ecl
 (progn
   (format t "--- COMPILING EXECUTABLE ---~%")
-  (asdf:make-build :vend
-                   :type :program
-                   :move-here #p"./"
-                   :epilogue-code '(vend:main))
+  (asdf:make :vend/executable)
   (format t "--- DONE ---~%")
-  (ext:quit 0))
+  (uiop:quit 0))

--- a/src/asd.lisp
+++ b/src/asd.lisp
@@ -48,7 +48,7 @@
                #'t:cons (directory (f:ensure-directory (f:join dir "*/")))))
 
 #++
-(root-asd-files (ext:getcwd))
+(root-asd-files (uiop:getcwd))
 #++
 (root-asd-files "/home/colin/code/common-lisp/zauberwald/")
 
@@ -452,7 +452,7 @@ while intelligently catching failures."
 (handler-bind ((clunit::test-suite-failure (lambda (c) (declare (ignore c)) (uiop:quit 1))))
   (clunit:run-all-suites :signal-condition-on-fail t :stop-on-fail t)
   (uiop:quit 0))
-" sys)))
+" #|sys|#)))
 
 #++
 (handler-bind ((clunit::test-suite-failure (lambda (c) (declare (ignore c)) (uiop:quit 1))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -8,9 +8,6 @@
 
 (in-package :vend)
 
-#-ecl
-(error "VEND can only be compiled with ECL.")
-
 ;; --- Strings --- ;;
 
 (declaim (ftype (function (string string &key (:from fixnum)) boolean) string-starts-with?))
@@ -97,9 +94,9 @@
   "Extra flags to pass to the compiler. The first list is for 'priority' flags that
 must come before any '--eval' flags."
   (cond ((string= "sbcl" compiler)  (values '("--noinform" "--non-interactive") '()))
-        ((string= "ecl" compiler)   (values '() '("--eval" "(ext:quit 0)")))
-        ((string= "abcl" compiler)  (values '("--noinform") '("--eval" "(ext:quit)")))
+        ((string= "ecl" compiler)   (values '() '("--eval" "(uiop:quit 0)")))
+        ((string= "abcl" compiler)  (values '("--noinform") '("--eval" "(uiop:quit)")))
         ((string= "alisp" compiler) (values '() '("--kill")))
-        ((string= "clisp" compiler) (values '("--silent") '("-x" "(ext:quit)")))
+        ((string= "clisp" compiler) (values '("--silent") '("-x" "(uiop:quit)")))
         ((string= "ccl" compiler)   (values '() '("--eval" "(ccl:quit)")))
         ((string= "cmucl" compiler) (values '("--quiet") '("--eval" "(quit)")))))

--- a/vend.asd
+++ b/vend.asd
@@ -1,13 +1,23 @@
 (defsystem "vend"
   :version "0.3.0"
   :author "Colin Woodbury <colin@fosskers.ca>"
-  :license "MPL-2.0"
-  :homepage "https://github.com/fosskers/vend"
-  :depends-on (:filepaths :simple-graph :transducers)
+  :license "MPL-2.0" :homepage "https://github.com/fosskers/vend"
+  :depends-on (:filepaths :simple-graph :transducers :asdf :uiop)
   :serial t
   :components ((:module "src"
                 :components ((:file "package")
                              (:file "registry")
                              (:file "asd")
                              (:file "vend"))))
-  :description "Simply vendor your Common Lisp project dependencies.")
+  :description "Simply vendor your Common Lisp project dependencies."
+  )
+
+
+
+(asdf:defsystem "vend/executable"
+  :depends-on ("vend")
+  :build-operation program-op
+  :build-pathname "vend" ;; shell name
+  :entry-point "vend:main" ;; thunk
+  )
+


### PR DESCRIPTION
Most ecl-specific calls could be trivially replaced with `uiop` calls, and given that asdf is already a dependency, this doesn't add any additional dependencies (`uiop` is part of asdf)

The ecl specific command line arguments parser has been replaced with a simple manual parser. This may require a little bit of testing, as I wasn't sure exactly what each of the sub-commands were intended to do because I could not get the ecl version to compile on my machine (which was one of my motivations for this port)

```sh
robertb@nobara-pc ~/c/vend (portability)> make
ecl --load build.lisp
;;; Loading #P"/home/robertb/common-lisp/vend/build.lisp"
;;; Loading #P"/usr/local/lib/ecl-24.5.10/asdf.fas"
--- LOADING SYSTEM ---
--- COMPILING EXECUTABLE ---
;;;
;;; Compiling /home/robertb/common-lisp/vend/vendored/filepaths/src/filepaths.lisp.
;;; OPTIMIZE levels: Safety=1, Space=0, Speed=3, Debug=1
;;;
;;; Internal error:
;;;   ** Error code 1 when executing
;;; (EXT:RUN-PROGRAM "gcc" ("-I." "-I/usr/local/include/" "-D_GNU_SOURCE" "-D_FILE_OFFSET_BITS=64" "-g" "-O2" "-fPIC" "-D_THREAD_SAFE" "-Dlinux" "-O2" "-c" "/home/robertb/.cache/common-lisp/ecl-24.5.10-7b546e7f-linux-x64/home/robertb/common-lisp/vend/vendored/filepaths/src/filepaths.c" "-o" "/home/robertb/.cache/common-lisp/ecl-24.5.10-7b546e7f-linux-x64/home/robertb/common-lisp/vend/vendored/filepaths/src/filepaths.o")):
;;; In file included from /usr/local/include/ecl/ecl.h:81,
;;;                  from /usr/local/include/ecl/ecl-cmp.h:31,
;;;                  from /home/robertb/.cache/common-lisp/ecl-24.5.10-7b546e7f-linux-x64/home/robertb/common-lisp/vend/vendored/filepaths/src/filepaths.c:5:
;;; /usr/local/include/ecl/object.h:27:13: error: ‘bool’ cannot be defined via ‘typedef’
;;;    27 | typedef int bool;
;;;       |             ^~~~
;;; /usr/local/include/ecl/object.h:27:13: note: ‘bool’ is a keyword with ‘-std=c23’ onwardsAn error occurred during initialization:
COMPILE-FILE-ERROR while
compiling #<cl-source-file "filepaths" "src" "filepaths">.
make: *** [Makefile:4: vend] Error 1
robertb@nobara-pc ~/c/vend (portability) [2]>
```

